### PR TITLE
feat: voucher rewards with code generation and validity radius

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -111,6 +111,8 @@ CREATE TABLE cards (
   base_score INTEGER DEFAULT 100,
   voucher_description TEXT,
   voucher_partner TEXT,
+  voucher_code TEXT,
+  voucher_validity_radius INTEGER DEFAULT 500,
   is_temporary_event BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMPTZ DEFAULT now()
 );

--- a/src/app/plan/[id]/play/page.tsx
+++ b/src/app/plan/[id]/play/page.tsx
@@ -13,7 +13,7 @@ import { VoucherCard } from "@/components/game/VoucherCard";
 import { HistoricalInfo } from "@/components/game/HistoricalInfo";
 import { GameMap } from "@/components/map/GameMap";
 import { useGeolocation } from "@/hooks/useGeolocation";
-import { calculateCheckInScore } from "@/lib/scoring";
+import { calculateCheckInScore, CHECK_IN_RADIUS } from "@/lib/scoring";
 import type { ScoreBreakdown } from "@/lib/scoring";
 import type { Card } from "@/lib/types";
 import type { HintLevel } from "@/components/game/GameCard";
@@ -39,6 +39,7 @@ export default function PlayPage() {
   const [lastDistance, setLastDistance] = useState(0);
   const [timerExpired, setTimerExpired] = useState(false);
   const [hintStep, setHintStep] = useState(0);
+  const [voucherUnlocked, setVoucherUnlocked] = useState(false);
 
   useEffect(() => {
     fetch(`/api/plans/${params.id}/cards`)
@@ -73,6 +74,8 @@ export default function PlayPage() {
 
   const handleQuizComplete = (answers: number[], correct: number) => {
     const score = calculateCheckInScore(lastDistance, currentCard?.base_score ?? 100, correct, timerExpired, hintStepToRevealed(hintStep));
+    const locationValid = lastDistance <= CHECK_IN_RADIUS;
+    setVoucherUnlocked(locationValid && correct > 0);
     setLastScore(score);
     setTotalScore((s) => s + score.total);
     setPhase("score");
@@ -87,6 +90,7 @@ export default function PlayPage() {
       setLastScore(null);
       setTimerExpired(false);
       setHintStep(0);
+      setVoucherUnlocked(false);
     }
   }, [isLastCard]);
 
@@ -224,8 +228,13 @@ export default function PlayPage() {
           <motion.div key="score" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col gap-4">
             <ScoreDisplay {...lastScore} />
 
-            {currentCard.voucher_description && (
-              <VoucherCard description={currentCard.voucher_description} partner={currentCard.voucher_partner} />
+            {voucherUnlocked && currentCard.voucher_description && (
+              <VoucherCard
+                description={currentCard.voucher_description}
+                partner={currentCard.voucher_partner}
+                code={currentCard.voucher_code}
+                validityRadius={currentCard.voucher_validity_radius}
+              />
             )}
 
             <button

--- a/src/components/game/GameCard.tsx
+++ b/src/components/game/GameCard.tsx
@@ -181,6 +181,9 @@ export function GameCard({ card, index = 0, hintLevel = "hard", onRevealHint }: 
               <div>
                 <p className="text-xs font-medium text-accent">Voucher</p>
                 <p className="text-xs text-foreground/60">{card.voucher_description}</p>
+                {card.voucher_partner && (
+                  <p className="text-xs text-foreground/40 mt-0.5">{card.voucher_partner}</p>
+                )}
               </div>
             </div>
           )}

--- a/src/components/game/VoucherCard.tsx
+++ b/src/components/game/VoucherCard.tsx
@@ -1,32 +1,71 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Gift, ExternalLink } from "lucide-react";
+import { Gift, ExternalLink, MapPin, Copy, Check } from "lucide-react";
+import { useState } from "react";
 
 interface VoucherCardProps {
   description: string;
   partner: string | null;
+  code: string | null;
+  validityRadius: number;
 }
 
-export function VoucherCard({ description, partner }: VoucherCardProps) {
+export function VoucherCard({ description, partner, code, validityRadius }: VoucherCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyCode = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API not available
+    }
+  };
+
+  const radiusLabel = validityRadius >= 1000
+    ? `${(validityRadius / 1000).toFixed(1)} km`
+    : `${validityRadius} m`;
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="rounded-2xl border border-accent/30 bg-gradient-to-br from-accent/10 to-accent/5 p-5 flex gap-4 items-start"
+      className="rounded-2xl border border-accent/30 bg-gradient-to-br from-accent/10 to-accent/5 p-5 flex flex-col gap-4"
     >
-      <div className="w-12 h-12 rounded-xl bg-accent/20 flex items-center justify-center shrink-0">
-        <Gift size={24} className="text-accent" />
+      <div className="flex gap-4 items-start">
+        <div className="w-12 h-12 rounded-xl bg-accent/20 flex items-center justify-center shrink-0">
+          <Gift size={24} className="text-accent" />
+        </div>
+        <div className="flex-1">
+          <p className="text-xs font-medium text-accent mb-1">Voucher sbloccato!</p>
+          <p className="text-sm text-foreground/80">{description}</p>
+          {partner && (
+            <p className="text-xs text-foreground/50 mt-1 flex items-center gap-1">
+              <ExternalLink size={12} /> {partner}
+            </p>
+          )}
+        </div>
       </div>
-      <div className="flex-1">
-        <p className="text-xs font-medium text-accent mb-1">Voucher sbloccato!</p>
-        <p className="text-sm text-foreground/80">{description}</p>
-        {partner && (
-          <p className="text-xs text-foreground/50 mt-1 flex items-center gap-1">
-            <ExternalLink size={12} /> {partner}
-          </p>
-        )}
-      </div>
+
+      {code && (
+        <div className="flex items-center justify-between gap-3 rounded-xl bg-white/5 border border-white/10 px-4 py-3">
+          <span className="font-mono text-lg font-bold tracking-widest text-accent">{code}</span>
+          <button
+            onClick={handleCopyCode}
+            className="p-2 rounded-lg bg-accent/10 hover:bg-accent/20 transition-colors"
+            aria-label="Copia codice"
+          >
+            {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} className="text-accent" />}
+          </button>
+        </div>
+      )}
+
+      <p className="text-xs text-foreground/40 flex items-center gap-1">
+        <MapPin size={12} /> Valido entro {radiusLabel} dalla tappa
+      </p>
     </motion.div>
   );
 }

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -30,6 +30,11 @@ REGOLE:
   - "common": luoghi permanenti, sempre visitabili (monumenti, ristoranti, parchi)
   - "rare": eventi temporanei (mostre, festival, concerti) attivi nel periodo di viaggio
   - "secret": carte Serendipity — luoghi nascosti, inaspettati, fuori dai percorsi turistici, scelti in base al profilo mood del giocatore. Massimo 1 carta secret per richiesta, e solo quando il luogo è davvero sorprendente
+- VOUCHER: Per ogni carta, genera un voucher realistico con un partner REALE nel raggio della tappa:
+  - "suggested_voucher": descrizione del premio (es. "Sconto 10% su tutti i gelati", "Caffè omaggio con acquisto di un dolce", "Ingresso ridotto alla mostra")
+  - "suggested_voucher_partner": nome del locale/attività REALE vicino al luogo (es. "Gelateria della Palma", "Caffè Sant'Eustachio")
+  - Il partner deve essere un'attività reale entro 500 metri dal luogo della carta
+  - Il voucher deve essere coerente con i mood della carta (food → sconti ristoranti/bar, art → musei/gallerie, shopping → negozi, etc.)
 
 RISPONDI SOLO con un JSON array di 3 oggetti con questa struttura:
 [{
@@ -46,7 +51,8 @@ RISPONDI SOLO con un JSON array di 3 oggetti con questa struttura:
   "is_temporary_event": false,
   "source_url": null,
   "source_name": null,
-  "suggested_voucher": "Sconto 10% al bar vicino",
+  "suggested_voucher": "Sconto 10% su tutti i gelati artigianali",
+  "suggested_voucher_partner": "Gelateria della Palma",
   "quiz_data": [
     {
       "question": "Domanda sul luogo",

--- a/src/lib/db-queries.ts
+++ b/src/lib/db-queries.ts
@@ -1,4 +1,5 @@
 import { query, queryOne } from "./db";
+import crypto from "node:crypto";
 import type {
   MoodProfile,
   Card,
@@ -10,6 +11,10 @@ import type {
   CardRarity,
 } from "./types";
 import { RARITY_POWER } from "./types";
+
+function generateVoucherCode(): string {
+  return `DT-${crypto.randomBytes(4).toString("hex").toUpperCase()}`;
+}
 
 // ── Profiles ──
 
@@ -129,11 +134,12 @@ export async function insertCards(
   for (const c of cards) {
     const rarity = c.rarity || "common";
     const powerLevel = RARITY_POWER[rarity] ?? 1;
+    const hasVoucher = Boolean(c.suggested_voucher);
     placeholders.push(
       `($${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++},
         $${idx++}::mood_type[], ST_SetSRID(ST_MakePoint($${idx++}, $${idx++}), 4326)::geography,
         $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++},
-        $${idx++}::card_rarity, $${idx++})`
+        $${idx++}, $${idx++}::card_rarity, $${idx++})`
     );
     values.push(
       planId,
@@ -151,7 +157,8 @@ export async function insertCards(
       c.hint_easy,
       c.historical_info,
       c.suggested_voucher || null,
-      null, // voucher_partner
+      c.suggested_voucher_partner || null,
+      hasVoucher ? generateVoucherCode() : null,
       c.is_temporary_event,
       rarity,
       powerLevel
@@ -161,8 +168,8 @@ export async function insertCards(
   return query<Card>(
     `INSERT INTO cards (plan_id, day_number, stage_order, title, description,
        moods, location, duration_min, quiz_data, hint_hard, hint_medium, hint_easy, historical_info,
-       voucher_description, voucher_partner, is_temporary_event,
-       rarity, power_level)
+       voucher_description, voucher_partner, voucher_code,
+       is_temporary_event, rarity, power_level)
      VALUES ${placeholders.join(", ")}
      RETURNING *, ST_Y(location::geometry) AS lat, ST_X(location::geometry) AS lon`,
     values
@@ -218,6 +225,7 @@ export async function insertCheckIn(
   hintsRevealed: number,
   scoreEarned: number
 ) {
+  const voucherUnlocked = locationValid && quizCorrect > 0;
   return queryOne(
     `INSERT INTO checkins
        (session_id, card_id, player_id, player_location,
@@ -225,12 +233,13 @@ export async function insertCheckIn(
         quiz_answers, quiz_correct, quiz_total, hints_revealed,
         score_earned, voucher_unlocked)
      VALUES ($1, $2, $3, ST_SetSRID(ST_MakePoint($5, $4), 4326)::geography,
-        $6, $7, $8, $9, $10, $11, $12, $13, $7)
+        $6, $7, $8, $9, $10, $11, $12, $13, $14)
      RETURNING *`,
     [
       sessionId, cardId, playerId, playerLat, playerLon,
       distanceMeters, locationValid, locationExact,
       JSON.stringify(quizAnswers), quizCorrect, quizTotal, hintsRevealed, scoreEarned,
+      voucherUnlocked,
     ]
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,8 @@ export interface Card {
   base_score: number;
   voucher_description: string | null;
   voucher_partner: string | null;
+  voucher_code: string | null;
+  voucher_validity_radius: number;
   is_temporary_event: boolean;
 }
 
@@ -210,6 +212,7 @@ export interface GeneratedCard {
   source_url: string | null;
   source_name: string | null;
   suggested_voucher: string | null;
+  suggested_voucher_partner: string | null;
   quiz_data: QuizQuestion[];
 }
 


### PR DESCRIPTION
## Summary
Closes #11

- **AI-generated voucher partners**: The card generation prompt now requests both `suggested_voucher` (description) and `suggested_voucher_partner` (real local business name within 500m of the stage location), producing realistic, mood-coherent vouchers
- **Voucher unlock gating**: Vouchers only unlock after a valid check-in (within radius) AND quiz completion (at least 1 correct answer) — previously displayed whenever `voucher_description` existed
- **Voucher code display**: Each card with a voucher gets a unique `DT-XXXXXXXX` code generated at plan creation time, shown in a copyable format on the VoucherCard component
- **Validity radius**: Cards store a `voucher_validity_radius` (default 500m), displayed on the VoucherCard as "Valido entro X m dalla tappa"
- **Enhanced VoucherCard**: Shows voucher code (with copy button), partner name, and validity radius
- **GameCard back**: Now displays partner name alongside voucher preview
- **DB schema**: Added `voucher_code` (TEXT) and `voucher_validity_radius` (INTEGER, default 500) columns to `cards` table

## Test plan
- [ ] Create a new plan and verify AI generates both `voucher_description` and `voucher_partner` for cards
- [ ] Play a plan, check in within radius, answer quiz correctly → voucher should appear with code
- [ ] Play a plan, check in outside radius → voucher should NOT appear
- [ ] Play a plan, check in within radius but answer 0 quiz questions correctly → voucher should NOT appear
- [ ] Verify voucher code copy button works
- [ ] Verify GameCard back side shows partner name under voucher description

🤖 Generated with [Claude Code](https://claude.com/claude-code)